### PR TITLE
Add support for rewriting date queries to use rollups with date_trunc_xxx columns.

### DIFF
--- a/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
+++ b/src/main/scala/com/socrata/querycoordinator/QueryRewriter.scala
@@ -269,7 +269,7 @@ class QueryRewriter(analyzer: SoQLAnalyzer[SoQLAnalysisType]) {
             if findFunctionOnColumn(rollupColIdx, dateTruncHierarchy, colRef).isDefined =>
         for {
           colIdx <- findFunctionOnColumn(rollupColIdx, dateTruncHierarchy, colRef)
-        } yield fc.copy(parameters =  Seq(ColumnRef(rollupColumnId(colIdx), colRef.typ)(fc.position)))(fc.position, fc.position)
+        } yield fc.copy(parameters =  Seq(ColumnRef(rollupColumnId(colIdx), colRef.typ)(fc.position)))(fc.position, fc.functionNamePosition)
 
       // remaining non-aggregate functions
       case fc: FunctionCall if fc.function.isAggregate == false =>

--- a/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncBase.scala
+++ b/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncBase.scala
@@ -1,0 +1,43 @@
+package com.socrata.querycoordinator
+
+import com.socrata.soql.environment.ColumnName
+
+class TestQueryRewriterDateTruncBase extends TestQueryRewriterBase {
+  /** Each rollup here is defined by:
+    * - a name
+    * - a soql statement.  Note this must be the mapped statement, ie. non-system columns prefixed by an _, and backtick escaped
+    * - a Seq of the soql types for each column in the rollup selection
+    */
+  val rollups = Seq(
+    ("r_ymd", "SELECT date_trunc_ymd(`_crim-date`), `:wido-ward`, count(*) GROUP BY date_trunc_ymd(`_crim-date`), `:wido-ward`"),
+    ("r_ym", "SELECT date_trunc_ym(`_crim-date`), `:wido-ward`, count(*) GROUP BY date_trunc_ym(`_crim-date`), `:wido-ward`"),
+    ("r_y", "SELECT date_trunc_y(`_crim-date`), `:wido-ward`, count(*) GROUP BY date_trunc_y(`_crim-date`), `:wido-ward`")
+  )
+
+  val rollupInfos = rollups.map { x => new RollupInfo(x._1, x._2)}
+
+  /** Pull in the rollupAnalysis for easier debugging */
+  val rollupAnalysis = rewriter.analyzeRollups(schema, rollupInfos)
+
+  val rollupRawSchemas = rollupAnalysis.mapValues { case analysis =>
+    analysis.selection.values.toSeq.zipWithIndex.map { case (expr, idx) =>
+      rewriter.rollupColumnId(idx) -> expr.typ.canonical
+    }.toMap
+  }
+
+  /** Analyze a "fake" query that has the rollup table column names in, so we
+    * can use it to compare  with the rewritten one in assertions.
+    */
+  def analyzeRewrittenQuery(rollupName: String, q: String) = {
+    val rewrittenRawSchema = rollupRawSchemas(rollupName)
+
+    val rollupNoopColumnNameMap = rewrittenRawSchema.map { case (k, v) => ColumnName(k) -> k}
+
+    val rollupDsContext = QueryParser.dsContext(rollupNoopColumnNameMap, rewrittenRawSchema)
+
+    val rewrittenQueryAnalysis = analyzer.analyzeFullQuery(q)(rollupDsContext).mapColumnIds(rollupNoopColumnNameMap)
+    rewrittenQueryAnalysis
+  }
+
+  def rewritesFor(q: String) = rewriter.possibleRewrites(analyzeQuery(q), rollupAnalysis)
+}

--- a/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncLtGte.scala
+++ b/src/test/scala/com/socrata/querycoordinator/TestQueryRewriterDateTruncLtGte.scala
@@ -1,0 +1,86 @@
+package com.socrata.querycoordinator
+
+import com.socrata.soql.functions.SoQLFunctions._
+import com.socrata.soql.types.SoQLFloatingTimestamp
+
+class TestQueryRewriterDateTruncLtGte extends TestQueryRewriterDateTruncBase {
+  val rewrittenQueryRymd = "SELECT c2 as ward, sum(c3) as count WHERE c1 >= '2011-03-08' AND c1 < '2019-08-02' GROUP BY c2"
+  val rewrittenQueryAnalysisRymd = analyzeRewrittenQuery("r_ymd", rewrittenQueryRymd)
+
+  val rewrittenQueryRym = "SELECT c2 as ward, sum(c3) as count WHERE c1 >= '2011-03-01' AND c1 < '2019-08-01' GROUP BY c2"
+  val rewrittenQueryAnalysisRym = analyzeRewrittenQuery("r_ymd", rewrittenQueryRym)
+
+  val rewrittenQueryRy = "SELECT c2 as ward, sum(c3) as count WHERE c1 >= '2011-01-01' AND c1 < '2019-01-01' GROUP BY c2"
+  val rewrittenQueryAnalysisRy = analyzeRewrittenQuery("r_y", rewrittenQueryRy)
+
+  test("year") {
+    val q = "SELECT ward, count(*) AS count WHERE " +
+      "crime_date >= '2011-01-01' AND crime_date < '2019-01-01' GROUP BY ward"
+    val rewrites = rewritesFor(q)
+
+    rewrites should contain key ("r_ymd")
+    rewrites.get("r_ymd").get should equal(rewrittenQueryAnalysisRy)
+    rewrites should contain key ("r_ym")
+    rewrites.get("r_ym").get should equal(rewrittenQueryAnalysisRy)
+    rewrites should contain key ("r_y")
+    rewrites.get("r_y").get should equal(rewrittenQueryAnalysisRy)
+
+    rewrites should have size (3)
+  }
+
+  test("month") {
+    val q = "SELECT ward, count(*) AS count WHERE " +
+      "crime_date >= '2011-03-01' AND crime_date < '2019-08-01' GROUP BY ward"
+    val rewrites = rewritesFor(q)
+
+    rewrites should contain key ("r_ymd")
+    rewrites.get("r_ymd").get should equal(rewrittenQueryAnalysisRym)
+    rewrites should contain key ("r_ym")
+    rewrites.get("r_ym").get should equal(rewrittenQueryAnalysisRym)
+
+    rewrites should have size (2)
+  }
+
+  test("day") {
+    val q = "SELECT ward, count(*) AS count WHERE " +
+      "crime_date >= '2011-03-08' AND crime_date < '2019-08-02' GROUP BY ward"
+    val rewrites = rewritesFor(q)
+
+    rewrites should contain key ("r_ymd")
+    rewrites.get("r_ymd").get should equal(rewrittenQueryAnalysisRymd)
+
+    rewrites should have size (1)
+  }
+
+  // Ensure that queries explicitly filtering out dates that javascript can't handle can hit rollups.
+  test("9999 filter") {
+    val q = "SELECT ward, count(*) AS count WHERE " +
+      "crime_date >= '2011-03-08' AND crime_date < '2019-08-02' AND crime_date < '9999-01-01' GROUP BY ward"
+    val rewrites = rewritesFor(q)
+
+    rewrites should contain key ("r_ymd")
+    rewrites.get("r_ymd").get should equal(analyzeRewrittenQuery("r_ymd",
+      "SELECT c2 as ward, sum(c3) as count WHERE c1 >= '2011-03-08' AND c1 < '2019-08-02' AND c1 < '9999-01-01' GROUP BY c2"))
+    rewrites should have size (1)
+  }
+
+  test("shouldn't rewrite") {
+    rewritesFor("SELECT ward WHERE crime_date < '2012-01-01T00:00:01'") should have size (0)
+    rewritesFor("SELECT ward WHERE crime_date <= '2012-01-01T00:00:00'") should have size (0)
+    rewritesFor("SELECT ward WHERE crime_date > '2012-01-01T00:00:00'") should have size (0)
+    rewritesFor("SELECT ward WHERE crime_date > '2012-01-01T01:00:00'") should have size (0)
+    rewritesFor("SELECT ward WHERE crime_date >= '2012-01-01T01:00:00' AND crime_date < '2013-01-01'") should have size (0)
+  }
+
+  test("truncatedTo") {
+    def ts(s: String) = SoQLFloatingTimestamp.apply(SoQLFloatingTimestamp.StringRep.unapply(s).get)
+    rewriter.truncatedTo(ts("2012-01-01")) should be (Some(FloatingTimeStampTruncY))
+    rewriter.truncatedTo(ts("2012-05-01")) should be (Some(FloatingTimeStampTruncYm))
+    rewriter.truncatedTo(ts("2012-05-09")) should be (Some(FloatingTimeStampTruncYmd))
+    rewriter.truncatedTo(ts("2012-05-09T01:00:00")) should be (None)
+    rewriter.truncatedTo(ts("2012-05-09T00:10:00")) should be (None)
+    rewriter.truncatedTo(ts("2012-05-09T00:00:02")) should be (None)
+    rewriter.truncatedTo(ts("2012-05-09T00:00:00.001")) should be (None)
+  }
+
+}


### PR DESCRIPTION
We do that by looking to see if the literal value passed in is the same as
the output from a date_trunc_xxx call, and if so substituting it where
"column > literal" or "column <= literal". The forms "literal < column" and
"literal >= column" are easy to add but not implemented.

See the scaladoc for the rewriteDateTruncGteLt method in QueryRewriter for
more details.